### PR TITLE
add default constructor values

### DIFF
--- a/src/main/kotlin/io/kotest/extensions/clock/TestClock.kt
+++ b/src/main/kotlin/io/kotest/extensions/clock/TestClock.kt
@@ -9,8 +9,8 @@ import kotlin.time.Duration
  * A mutable [Clock] that supports millisecond precision.
  */
 class TestClock(
-   private var instant: Instant,
-   private val zone: ZoneId,
+   private var instant: Instant = Instant.now(),
+   private val zone: ZoneId = ZoneId.systemDefault(),
 ) : Clock() {
 
    override fun instant(): Instant = instant


### PR DESCRIPTION
small usability improvement. When creating a test clock I usually don't care about the exact time (although it is nice to have the option.